### PR TITLE
Add min node version check

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 package-lock=false
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -94,5 +94,8 @@
     "atLeast": 100,
     "detail": true,
     "strict": true
+  },
+  "engines": {
+    "node": ">=18.0.0"
   }
 }


### PR DESCRIPTION
`test.js` requires `node:test`, so therefore the project requires node v18+. These additions ensure node v18+ is installed.